### PR TITLE
v0.1.2 - rename strings.Format() to strings.ToString()

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ o, _ = shell.Execute(cmd)
 Package strings provide helper functions related to string
 #### Overview
 Package strings contains extensions of standard strings and formatting functions:
-- `Format(v interface{}) string` Format converts type to formatted string. If value is struct, function returns formatted JSON.
+- `ToString(v interface{}) string` Format converts type to formatted string. If value is struct, function returns formatted JSON.
 
 #### Usage
 ```go

--- a/strings/string.go
+++ b/strings/string.go
@@ -23,14 +23,14 @@ import (
 	"fmt"
 )
 
-// Format converts type to formatted string. If value is struct, function returns formatted JSON.
+// ToString converts type to formatted string. If value is struct, function returns formatted JSON.
 // Function retrieves // null for nil pointer references. Function doesn't return error. In case of
 // marshal error it converts with %v formatter
 // Only two possible errors can occur e.g.:
-//		UnsupportedTypeError Format(make(chan int));
-//		UnsupportedValueError Format(math.Inf(1));
+//		UnsupportedTypeError ToString(make(chan int));
+//		UnsupportedValueError ToString(math.Inf(1));
 // In both cases function retrieves expected result. The pointer address in the first while "+Inf" in second
-func Format(v interface{}) string {
+func ToString(v interface{}) string {
 	value, err := json.MarshalIndent(v, "", "\t")
 	if err != nil {
 		return fmt.Sprintf("%v", v)


### PR DESCRIPTION
related to [k8gb #387](https://github.com/AbsaOSS/k8gb/pull/387#pullrequestreview-616998163)