### PR TITLE
Make Dig configurable whether it should use TCP or UDP

### DIFF
--- a/dns/dns.go
+++ b/dns/dns.go
@@ -26,12 +26,16 @@ import (
 )
 
 // Dig retrieves list of tuple <IP address, A record > from edge DNS server for specific FQDN
-func Dig(edgeDNSServer, fqdn string) ([]string, error) {
+// if useUDP is false, the TCP protocol will be used
+func Dig(edgeDNSServer, fqdn string, useUDP bool) ([]string, error) {
 	var dig dnsutil.Dig
 	if edgeDNSServer == "" {
 		return nil, fmt.Errorf("empty edgeDNSServer")
 	}
 	err := dig.SetDNS(edgeDNSServer)
+	if !useUDP {
+		dig.Protocol = "tcp"
+	}
 	if err != nil {
 		err = fmt.Errorf("dig error: can't set query dns (%s) with error(%s)", edgeDNSServer, err)
 		return nil, err


### PR DESCRIPTION
why:
When running lima VM as a backend for docker cli, it can't properly tunnel the UDP ports so we need to tell our terratests to go via tcp

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>