### PR TITLE
Test for tcp dig + fixing the dns tests

### DIFF
--- a/.github/workflows/inspect.yaml
+++ b/.github/workflows/inspect.yaml
@@ -1,7 +1,13 @@
 name: Inspect [linters, tests]
 
 on:
-  [workflow_dispatch, push]
+  workflow_dispatch:
+  push:
+    paths-ignore: ['**.md']
+  pull_request:
+    paths-ignore: ['**.md']
+    branches:
+      - master
 jobs:
   go-inspect:
     name: Inspect packages

--- a/dns/dns_test.go
+++ b/dns/dns_test.go
@@ -24,15 +24,32 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const googleDNS = "8.8.8.8"
+
 func TestValidDig(t *testing.T) {
 	// arrange
 	if !connected() {
 		t.Skipf("no connectivity, skipping")
 	}
-	edgeDNSServer := "8.8.8.8"
+	edgeDNSServer := googleDNS
 	fqdn := "google.com"
 	// act
-	result, err := Dig(edgeDNSServer, fqdn)
+	result, err := Dig(edgeDNSServer, fqdn, false)
+	// assert
+	assert.NoError(t, err)
+	assert.NotEmpty(t, result)
+	assert.NotEmpty(t, result[0])
+}
+
+func TestValidDigTCP(t *testing.T) {
+	// arrange
+	if !connected() {
+		t.Skipf("no connectivity, skipping")
+	}
+	edgeDNSServer := googleDNS
+	fqdn := "google.com"
+	// act
+	result, err := Dig(edgeDNSServer, fqdn, true)
 	// assert
 	assert.NoError(t, err)
 	assert.NotEmpty(t, result)
@@ -44,10 +61,10 @@ func TestEmptyFQDNButValidEdgeDNS(t *testing.T) {
 	if !connected() {
 		t.Skipf("no connectivity, skipping")
 	}
-	edgeDNSServer := "8.8.8.8"
+	edgeDNSServer := googleDNS
 	fqdn := ""
 	// act
-	result, err := Dig(edgeDNSServer, fqdn)
+	result, err := Dig(edgeDNSServer, fqdn, false)
 	// assert
 	assert.NoError(t, err)
 	assert.Nil(t, result)
@@ -58,7 +75,7 @@ func TestEmptyEdgeDNS(t *testing.T) {
 	edgeDNSServer := ""
 	fqdn := "whatever"
 	// act
-	result, err := Dig(edgeDNSServer, fqdn)
+	result, err := Dig(edgeDNSServer, fqdn, false)
 	// assert
 	assert.Error(t, err)
 	assert.Nil(t, result)
@@ -69,7 +86,7 @@ func TestValidEdgeDNSButNonExistingFQDN(t *testing.T) {
 	edgeDNSServer := "localhost"
 	fqdn := "some-valid-ip-fqdn-123"
 	// act
-	result, err := Dig(edgeDNSServer, fqdn)
+	result, err := Dig(edgeDNSServer, fqdn, false)
 	// assert
 	assert.Error(t, err)
 	assert.Nil(t, result)


### PR DESCRIPTION
Not sure why, but the tests were not run on my previous PR so I missed this.

update: it wasn't run because of [this](https://github.com/AbsaOSS/gopkg/blob/main/.github/workflows/inspect.yaml#L4). Not run on PRs, so I am adding this also to this PR.

I've verified that the changes to the workflow file works on my [fork&test PR](https://github.com/jkremser/gopkg/pull/3)

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>